### PR TITLE
Small issue on slide 34

### DIFF
--- a/source/presentations/session02.rst
+++ b/source/presentations/session02.rst
@@ -485,7 +485,7 @@ Once we have that, we can play with the resulting email object:
      'To', 'Mime-Version', 'X-Mailer']
     >>> msg['To']
     'demo@crisewing.com'
-    >>> print msg.get_payload()
+    >>> print msg.get_payload()[0]
     If you are reading this email, ...
 
 .. class:: incremental center


### PR DESCRIPTION
When I run it, print msg.get_payload() returns a list:

> > > print msg.get_payload()
> > > [<email.message.Message instance at 0x10124c680>, <email.message.Message instance at 0x10124c560>]
